### PR TITLE
feat: separate ticket and reservation flows

### DIFF
--- a/Web/src/pages/booking.vue
+++ b/Web/src/pages/booking.vue
@@ -62,9 +62,20 @@
             </label>
         </div>
 
+        <!-- 優惠券 -->
+        <div class="bg-white border p-4 mb-4 shadow">
+            <label class="block mb-2 font-semibold">套用優惠券</label>
+            <div class="flex gap-2">
+                <input v-model="couponCode" type="text" placeholder="輸入票券編號"
+                    class="flex-1 border px-2 py-1" />
+                <button @click="applyCoupon" class="px-4 bg-[#D90000] text-white">套用</button>
+            </div>
+            <p v-if="couponDiscount" class="text-green-600 mt-2">已折抵 {{ couponDiscount }} 元</p>
+        </div>
+
         <!-- 總金額 -->
         <div class="text-lg font-bold text-right mb-4">
-            總金額：TWD {{ totalPrice }}
+            總金額：TWD {{ finalPrice }}
         </div>
 
         <button @click="reserve" class="w-full bg-[#D90000] text-white py-2 hover:bg-[#B00000]">
@@ -192,12 +203,32 @@
         return sum >= 20 ? Math.round(sum * 0.9) : sum
     })
 
+    // 優惠券
+    const couponCode = ref('')
+    const couponDiscount = ref(0)
+    const coupons = ref([
+        { code: 'a1', discount: 100, used: false },
+        { code: 'b2', discount: 150, used: false },
+        { code: 'd4', discount: 200, used: false },
+    ])
+    const applyCoupon = () => {
+        const coupon = coupons.value.find(c => c.code === couponCode.value && !c.used)
+        if (coupon) {
+            couponDiscount.value = coupon.discount
+            coupon.used = true
+            alert(`已套用優惠券，折抵 ${coupon.discount} 元`)
+        } else {
+            alert('優惠券不可用')
+        }
+    }
+    const finalPrice = computed(() => Math.max(totalPrice.value - couponDiscount.value, 0))
+
     const reserve = () => {
         if (!addOn.value.nakedConfirm || !addOn.value.purchasePolicy || !addOn.value.usagePolicy) {
             alert('請確認已閱讀並同意所有規定')
             return
         }
-        alert(`✅ 已成功預約\n總金額：${totalPrice.value} 元`)
+        alert(`✅ 已成功預約\n總金額：${finalPrice.value} 元`)
     }
 </script>
 

--- a/Web/src/pages/order.vue
+++ b/Web/src/pages/order.vue
@@ -1,7 +1,7 @@
 <template>
     <main class="pt-6 pb-12 px-4">
         <div class="max-w-5xl mx-auto">
-            <h1 class="text-2xl font-bold text-[#D90000] mb-6 text-center">我的訂單</h1>
+            <h1 class="text-2xl font-bold text-[#D90000] mb-6 text-center">票券訂單</h1>
 
             <div v-if="orders.length > 0" class="space-y-4">
                 <div v-for="order in orders" :key="order.id"

--- a/Web/src/pages/store.vue
+++ b/Web/src/pages/store.vue
@@ -75,10 +75,10 @@
                 <p v-else class="text-center text-gray-500">購物車目前是空的</p>
             </section>
 
-            <!-- 📦 訂單 -->
+            <!-- 📦 票券訂單 -->
             <section v-if="activeTab === 'orders'" class="slide-in">
-                <div v-if="orders.length" class="space-y-4">
-                    <div v-for="order in orders" :key="order.id"
+                <div v-if="ticketOrders.length" class="space-y-4">
+                    <div v-for="order in ticketOrders" :key="order.id"
                         class="ticket-card bg-white border-2 border-gray-100 p-5 shadow-sm hover:shadow-lg transition">
                         <p><strong>訂單編號：</strong>{{ order.id }}</p>
                         <p><strong>票券種類：</strong>{{ order.ticketType }}</p>
@@ -207,7 +207,7 @@
         const randomNum = Math.floor(1000 + Math.random() * 9000)
         return `${prefix}${randomNum}`
     }
-    const orders = ref([
+    const ticketOrders = ref([
         { id: 'ORD-001', ticketType: '小鐵人', quantity: 2, total: 600, createdAt: '2025-07-21', status: '已完成' },
         { id: 'ORD-002', ticketType: '滑步車', quantity: 1, total: 200, createdAt: '2025-07-22', status: '處理中' },
     ])
@@ -217,7 +217,7 @@
             return
         }
         cartItems.value.forEach(item => {
-            orders.value.push({
+            ticketOrders.value.push({
                 id: generateOrderId(),
                 ticketType: item.name,
                 quantity: item.quantity,

--- a/Web/src/pages/wallet.vue
+++ b/Web/src/pages/wallet.vue
@@ -6,12 +6,12 @@
             <header class="bg-white shadow-sm border-b border-gray-100 mb-8 p-6">
                 <div class="flex items-center justify-between">
                     <div>
-                        <h1 class="text-2xl font-bold text-gray-900">票券管理中心</h1>
-                        <p class="text-gray-600 mt-1">管理您的所有票券與預約紀錄</p>
+                        <h1 class="text-2xl font-bold text-gray-900">優惠券管理中心</h1>
+                        <p class="text-gray-600 mt-1">管理您的所有優惠券與預約紀錄</p>
                     </div>
                     <div class="flex items-center space-x-4">
                         <div class="bg-red-50 text-red-700 px-4 py-2 text-sm font-medium">
-                            共 {{ totalTickets }} 張票券
+                            共 {{ totalTickets }} 張優惠券
                         </div>
                     </div>
                 </div>
@@ -35,18 +35,18 @@
                 </div>
             </div>
 
-            <!-- 我的票券 -->
+            <!-- 我的優惠券 -->
             <section v-if="activeTab === 'tickets'" class="slide-in">
                 <!-- Stats Cards -->
                 <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
                     <div @click="filterTickets('all')"
                         class="cursor-pointer bg-white p-6 border border-gray-200 shadow-sm hover:border-[#D90000]">
-                        <p class="text-sm text-gray-600 font-medium">總票券數</p>
+                        <p class="text-sm text-gray-600 font-medium">總優惠券數</p>
                         <p class="text-3xl font-bold text-gray-900">{{ totalTickets }}</p>
                     </div>
                     <div @click="filterTickets('available')"
                         class="cursor-pointer bg-white p-6 border border-gray-200 shadow-sm hover:border-[#D90000]">
-                        <p class="text-sm text-gray-600 font-medium">可用票券</p>
+                        <p class="text-sm text-gray-600 font-medium">可用優惠券</p>
                         <p class="text-3xl font-bold text-green-600">{{ availableTickets }}</p>
                     </div>
                     <div @click="filterTickets('used')"
@@ -66,7 +66,7 @@
                         :class="filter === 'used' ? activeFilterClass : defaultFilterClass">已使用</button>
                 </div>
 
-                <!-- Ticket Cards -->
+                <!-- Coupon Cards -->
                 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
                     <div v-for="(ticket, index) in filteredTickets" :key="ticket.uuid" :class="[
                         'ticket-card bg-white border-2 border-gray-100 p-6 shadow-sm',
@@ -84,13 +84,13 @@
                                 {{ ticket.used ? '已使用' : '未使用' }}
                             </span>
                         </div>
-                        <p class="text-xs text-gray-500 mb-1">票券編號</p>
+                        <p class="text-xs text-gray-500 mb-1">優惠券編號</p>
                         <p class="text-sm font-mono bg-gray-50 p-2 text-gray-700 break-all mb-4">{{ ticket.uuid }}</p>
                         <button class="w-full py-3 font-semibold text-white" :class="ticket.used
                             ? 'bg-gray-400 cursor-not-allowed'
                             : 'bg-[#D90000] hover:bg-[#B00000] transition'" :disabled="ticket.used"
                             @click="useTicket(index)">
-                            {{ ticket.used ? '已使用 ✅' : '使用票券' }}
+                            {{ ticket.used ? '已使用 ✅' : '使用優惠券' }}
                         </button>
                     </div>
                 </div>
@@ -147,7 +147,7 @@
                     <button @click="closeModal"
                         class="absolute top-3 right-3 text-gray-500 hover:text-red-500">✕</button>
                     <h3 class="text-xl font-bold text-[#D90000] mb-4">預約詳情</h3>
-                    <p><strong>票券類型：</strong>{{ selectedReservation.ticketType }}</p>
+                    <p><strong>優惠券類型：</strong>{{ selectedReservation.ticketType }}</p>
                     <p><strong>門市：</strong>{{ selectedReservation.store }}</p>
                     <p><strong>賽事：</strong>{{ selectedReservation.event }}</p>
                     <p><strong>預約時間：</strong>{{ selectedReservation.reservedAt }}</p>
@@ -175,7 +175,7 @@
     import QrcodeVue from 'qrcode.vue'
 
     const tabs = [
-        { key: 'tickets', label: '我的票券' },
+        { key: 'tickets', label: '我的優惠券' },
         { key: 'reservations', label: '我的預約' },
     ]
     const activeTab = ref('tickets')
@@ -188,7 +188,7 @@
     const activeFilterClass = 'px-4 py-2 bg-[#D90000] text-white font-medium'
     const defaultFilterClass = 'px-4 py-2 bg-gray-100 text-gray-700 hover:bg-gray-200'
 
-    // 票券資料
+    // 優惠券資料
     const tickets = ref([
         { type: '小鐵人', expiry: '2025-12-31', uuid: 'a1', used: false },
         { type: '大鐵人', expiry: '2025-08-01', uuid: 'b2', used: false },
@@ -209,7 +209,7 @@
     const useTicket = (index) => {
         if (!tickets.value[index].used) {
             tickets.value[index].used = true
-            alert(`票券「${tickets.value[index].type}」已成功使用！`)
+            alert(`優惠券「${tickets.value[index].type}」已成功使用！`)
         }
     }
 


### PR DESCRIPTION
## Summary
- split ticket purchase orders from reservation flow
- allow applying ticket codes as coupons during reservation
- rename wallet management to handle coupons

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6895b16b0e4c83288cc220fd3ee8ccbc